### PR TITLE
Schedule view page [Issue 27]

### DIFF
--- a/components/WeekViewCalendar.vue
+++ b/components/WeekViewCalendar.vue
@@ -1,4 +1,4 @@
-<!-- 8 Apr 2025 coder-Mika
+<!-- 9 Apr 2025
 
 	Calendar displays days from Monday-Friday given a list of appointments. The hours adjust to the earliest and latest times of all the appointments being displayed.
 -->
@@ -63,7 +63,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch, toRef } from "vue";
+import { computed, ref, watch } from "vue";
 import type { Session } from "@prisma/client";
 
 const user = {
@@ -212,10 +212,13 @@ const props = defineProps<{
 	week: Date; // any day in the week wanted to be displayed. week starts at monday
 }>();
 
-const weekDate = toRef(props, "week");
-watch(weekDate, () => {
-	thisWeekSessions.value = getFilteredSessions(user.Sessions);
-});
+// get new sessions when week chances
+watch(
+	() => props.week,
+	() => {
+		thisWeekSessions.value = getFilteredSessions(user.Sessions);
+	}
+);
 
 // a 2d array holding all the sessions that should be displayed. [day-1][session in the list]
 const thisWeekSessions = ref(getFilteredSessions(user.Sessions));
@@ -320,7 +323,7 @@ function getFilteredSessions(allSessions: Session[]): Session[][] {
 	}
 
 	// get the monday of the week
-	let monday = getMonday(weekDate.value);
+	let monday = getMonday(props.week);
 	for (let i = 0; i < allSessions.length; i++) {
 		let currSessionDay = new Date(allSessions[i].time);
 

--- a/components/WeekViewCalendar.vue
+++ b/components/WeekViewCalendar.vue
@@ -1,4 +1,4 @@
-<!-- 7 Apr 2025 coder-Mika
+<!-- 8 Apr 2025 coder-Mika
 
 	Calendar displays days from Monday-Friday given a list of appointments. The hours adjust to the earliest and latest times of all the appointments being displayed.
 -->
@@ -63,7 +63,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from "vue";
+import { computed, ref, watch, toRef } from "vue";
 import type { Session } from "@prisma/client";
 
 const user = {
@@ -141,7 +141,7 @@ const user = {
 		},
 		{
 			id: "4",
-			time: "April 4, 2025 12:45:00",
+			time: "April 8, 2025 12:45:00",
 			duration: 50,
 			comment: "hi",
 			maxAttendance: 2,
@@ -212,8 +212,12 @@ const props = defineProps<{
 	week: Date; // any day in the week wanted to be displayed. week starts at monday
 }>();
 
+const weekDate = toRef(props, "week");
+watch(weekDate, () => {
+	thisWeekSessions.value = getFilteredSessions(user.Sessions);
+});
+
 // a 2d array holding all the sessions that should be displayed. [day-1][session in the list]
-//const thisWeekSessions = getFilteredSessions(props.sessions);
 const thisWeekSessions = ref(getFilteredSessions(user.Sessions));
 
 const dayNames = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
@@ -293,8 +297,6 @@ function militaryTimeToTwelveHr(h: number): string {
 
 const rowHeight = ref(26); // height in pixels of each row of time for the appointment box component
 
-// functions
-
 // given a date, gets the monday of that week (assuming the week starts on monday)
 function getMonday(d: Date): Date {
 	// if day is sunday, go back to the monday of that week
@@ -318,7 +320,7 @@ function getFilteredSessions(allSessions: Session[]): Session[][] {
 	}
 
 	// get the monday of the week
-	let monday = getMonday(props.week);
+	let monday = getMonday(weekDate.value);
 	for (let i = 0; i < allSessions.length; i++) {
 		let currSessionDay = new Date(allSessions[i].time);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@heroicons/vue": "^2.2.0",
 				"@prisma/client": "^6.3.0",
 				"@tailwindcss/vite": "^4.0.1",
+				"@vueuse/core": "^13.1.0",
 				"nuxt": "^3.15.4",
 				"tailwindcss": "^4.0.1",
 				"vue": "latest",
@@ -3138,6 +3139,12 @@
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"license": "MIT"
 		},
+		"node_modules/@types/web-bluetooth": {
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+			"integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+			"license": "MIT"
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.22.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.22.0.tgz",
@@ -3740,6 +3747,44 @@
 			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
 			"integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
 			"license": "MIT"
+		},
+		"node_modules/@vueuse/core": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.1.0.tgz",
+			"integrity": "sha512-PAauvdRXZvTWXtGLg8cPUFjiZEddTqmogdwYpnn60t08AA5a8Q4hZokBnpTOnVNqySlFlTcRYIC8OqreV4hv3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/web-bluetooth": "^0.0.21",
+				"@vueuse/metadata": "13.1.0",
+				"@vueuse/shared": "13.1.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vue": "^3.5.0"
+			}
+		},
+		"node_modules/@vueuse/metadata": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.1.0.tgz",
+			"integrity": "sha512-+TDd7/a78jale5YbHX9KHW3cEDav1lz1JptwDvep2zSG8XjCsVE+9mHIzjTOaPbHUAk5XiE4jXLz51/tS+aKQw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/@vueuse/shared": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.1.0.tgz",
+			"integrity": "sha512-IVS/qRRjhPTZ6C2/AM3jieqXACGwFZwWTdw5sNTSKk2m/ZpkuuN+ri+WCVUP8TqaKwJYt/KuMwmXspMAw8E6ew==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vue": "^3.5.0"
+			}
 		},
 		"node_modules/abbrev": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@heroicons/vue": "^2.2.0",
 		"@prisma/client": "^6.3.0",
 		"@tailwindcss/vite": "^4.0.1",
+		"@vueuse/core": "^13.1.0",
 		"nuxt": "^3.15.4",
 		"tailwindcss": "^4.0.1",
 		"vue": "latest",

--- a/pages/ScheduleView.vue
+++ b/pages/ScheduleView.vue
@@ -1,0 +1,86 @@
+<!-- 8 Apr 2025
+ schedule view page, clicking the buttons changes the week that's being displayed -->
+<template>
+	<div class="m-10">
+		<div class="my-5">
+			<div class="text-xl">Current Schedule for</div>
+			<div class="text-3xl">{{ currentWeek }}</div>
+		</div>
+
+		<div class="flex justify-center">
+			<div class="px-2 align-top text-xl">
+				<button @click="changeWeek(false)">&#x25C0;</button>
+			</div>
+
+			<WeekViewCalendar :week="date" />
+			<div class="px-2 align-top text-xl">
+				<button @click="changeWeek(true)">&#x25B6;</button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+const date = ref<Date>();
+date.value = new Date(Date.now());
+
+const monthNames = [
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December",
+];
+
+// gets the monday & friday given the current date
+const currentWeek = ref("");
+getCurrentWeek();
+
+//updates the current week
+function getCurrentWeek() {
+	// get monday & friday
+	const firstDay =
+		date.value.getDate() -
+		date.value.getDay() +
+		(date.value.getDay() == 0 ? -6 : 1);
+	let monday = new Date(date.value.getTime());
+	monday.setDate(firstDay);
+	let friday = new Date(date.value.getTime());
+	friday.setDate(firstDay + 4);
+
+	const result =
+		monday.getDate() +
+		" " +
+		monthNames[monday.getMonth()] +
+		" " +
+		monday.getFullYear() +
+		" to " +
+		friday.getDate() +
+		" " +
+		monthNames[friday.getMonth()] +
+		" " +
+		friday.getFullYear();
+
+	currentWeek.value = result;
+}
+
+// true is moving forward, false is moving back a week
+function changeWeek(forward: boolean) {
+	console.log("clicky clicky");
+	if (forward) {
+		date.value.setDate(date.value.getDate() + 7);
+	} else {
+		date.value.setDate(date.value.getDate() - 7);
+	}
+
+	getCurrentWeek();
+}
+</script>

--- a/pages/ScheduleView.vue
+++ b/pages/ScheduleView.vue
@@ -1,26 +1,33 @@
-<!-- 8 Apr 2025
+<!-- 9 Apr 2025
  schedule view page, clicking the buttons changes the week that's being displayed -->
 <template>
 	<div class="m-10">
 		<!-- Title part + option buttons -->
 		<div class="my-5 flex justify-between">
 			<div class="flex flex-col justify-center">
-				<div class="text-xl">Current Schedule for</div>
+				<div class="text-xl">Schedule for</div>
 				<div class="text-3xl">{{ currentWeek }}</div>
 			</div>
-			<div>
-				<createAppointment />
-				<button @click="filterAppointments()">Filter</button>
+			<div class="justify-right flex flex-col gap-2">
+				<createAppointment v-if="permissions.editAppointments" />
+				<!-- placeholder style for the button so it's not just text lmao -->
+				<button
+					@click="filterAppointments()"
+					class="bg-blue-950 p-2 text-white"
+					v-if="permissions.filter"
+				>
+					Filter
+				</button>
 			</div>
 		</div>
 
 		<div class="flex justify-center">
-			<div class="px-2 align-top text-xl">
+			<div class="pr-3 align-top text-3xl">
 				<button @click="changeWeek(false)">&#x25C0;</button>
 			</div>
 
 			<WeekViewCalendar :week="date" />
-			<div class="px-2 align-top text-xl">
+			<div class="pl-3 align-top text-3xl">
 				<button @click="changeWeek(true)">&#x25B6;</button>
 			</div>
 		</div>
@@ -29,6 +36,13 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+
+// will be removed later, for now defines the user's permissions
+const permissions = {
+	filter: true, // user service/admin = true, admin/patient/therapist = false
+	editAppointments: true, // user service = true, admin/patient/therapist = false
+};
+
 const date = ref<Date>();
 date.value = new Date(Date.now());
 

--- a/pages/ScheduleView.vue
+++ b/pages/ScheduleView.vue
@@ -21,12 +21,13 @@
 			</div>
 		</div>
 
-		<div class="flex justify-center">
+		<!-- Calendar part -->
+		<div class="flex w-full justify-center">
 			<div class="pr-3 align-top text-3xl">
 				<button @click="changeWeek(false)">&#x25C0;</button>
 			</div>
 
-			<WeekViewCalendar :week="date" />
+			<WeekViewCalendar :week="date" class="grow" />
 			<div class="pl-3 align-top text-3xl">
 				<button @click="changeWeek(true)">&#x25B6;</button>
 			</div>

--- a/pages/ScheduleView.vue
+++ b/pages/ScheduleView.vue
@@ -2,9 +2,16 @@
  schedule view page, clicking the buttons changes the week that's being displayed -->
 <template>
 	<div class="m-10">
-		<div class="my-5">
-			<div class="text-xl">Current Schedule for</div>
-			<div class="text-3xl">{{ currentWeek }}</div>
+		<!-- Title part + option buttons -->
+		<div class="my-5 flex justify-between">
+			<div class="flex flex-col justify-center">
+				<div class="text-xl">Current Schedule for</div>
+				<div class="text-3xl">{{ currentWeek }}</div>
+			</div>
+			<div>
+				<createAppointment />
+				<button @click="filterAppointments()">Filter</button>
+			</div>
 		</div>
 
 		<div class="flex justify-center">
@@ -74,13 +81,16 @@ function getCurrentWeek() {
 
 // true is moving forward, false is moving back a week
 function changeWeek(forward: boolean) {
-	console.log("clicky clicky");
 	if (forward) {
-		date.value.setDate(date.value.getDate() + 7);
+		date.value = new Date(date.value.setDate(date.value.getDate() + 7));
 	} else {
-		date.value.setDate(date.value.getDate() - 7);
+		date.value = new Date(date.value.setDate(date.value.getDate() - 7));
 	}
 
 	getCurrentWeek();
+}
+
+function filterAppointments() {
+	console.log("filter button clicky clicky");
 }
 </script>

--- a/pages/ScheduleViewEx.vue
+++ b/pages/ScheduleViewEx.vue
@@ -1,7 +1,0 @@
-<template>
-	<WeekViewCalendar :week="date" />
-</template>
-
-<script setup lang="ts">
-const date = new Date("March 31, 2025 13:00:00");
-</script>


### PR DESCRIPTION
Clicking the arrow buttons lets you switch between weeks. By default, it starts at the current week. For testing purposes, the appointments that are available are in the week of 31 March and the week of 7 April. Filter button doesn't do anything yet, i'll be adding an issue for that specifically