### PR TITLE
wont create a new appointment when there the max attendence is too big: FIXED

### DIFF
--- a/components/createAppointment.vue
+++ b/components/createAppointment.vue
@@ -229,7 +229,13 @@ function enforceMin() {
 
 // Submit form handler
 async function submitForm() {
-	// 1) basic client-side validation
+	const MAX_PATIENTS = 20; //Max Patients should be between 1 and 20 which is reasonable before being fetched into the database
+	const maxPatients = Number(form.max);
+	if (isNaN(maxPatients) || maxPatients < 1 || maxPatients > MAX_PATIENTS) {
+		alert(`Max patients must be a number between 1 and ${MAX_PATIENTS}`);
+		return;
+	}
+
 	if (!form.therapist || !form.sessionType || !form.date || !form.time) {
 		alert("Please fill out all required fields.");
 		return;
@@ -243,7 +249,7 @@ async function submitForm() {
 		typeId: form.sessionType, // string
 		time: dateTime, // JS Date
 		duration: form.duration, // number ≥1
-		maxAttendance: form.max, // number ≥1
+		maxAttendance: maxPatients, // number ≥1
 		comment: form.comments || undefined,
 	};
 

--- a/components/editAppointment.vue
+++ b/components/editAppointment.vue
@@ -185,13 +185,20 @@ async function submitForm() {
 	const sessionTime = new Date(
 		form.date && form.time ? `${form.date}T${form.time}:00` : ""
 	);
+
+	const MAX_PATIENTS = 20; //Max Patients should be between 1 and 20 which is reasonable before being fetched into the database
+	const maxPatients = Number(form.max);
+	if (isNaN(maxPatients) || maxPatients < 1 || maxPatients > MAX_PATIENTS) {
+		alert(`Max patients must be a number between 1 and ${MAX_PATIENTS}`);
+		return;
+	}
 	const sessionData = {
 		id: props.session.id,
 		therapistId: form.therapist,
 		typeId: form.sessionType,
 		time: sessionTime.toISOString(),
 		duration: form.duration,
-		maxAttendance: form.max,
+		maxAttendance: maxPatients,
 		comment: form.comments,
 	};
 

--- a/components/editAppointment.vue
+++ b/components/editAppointment.vue
@@ -192,6 +192,7 @@ async function submitForm() {
 		alert(`Max patients must be a number between 1 and ${MAX_PATIENTS}`);
 		return;
 	}
+
 	const sessionData = {
 		id: props.session.id,
 		therapistId: form.therapist,


### PR DESCRIPTION
There was no limit for max patients when creating or editing an appointment. Validation has been implemented which accounts for max patients always being in the range from 1-20 which is quite reasonable.